### PR TITLE
Fix links and pyglet version

### DIFF
--- a/1_getting_started.ipynb
+++ b/1_getting_started.ipynb
@@ -76,6 +76,7 @@
       "source": [
         "!apt-get install ffmpeg freeglut3-dev xvfb  # For visualization\n",
         "!pip install stable-baselines3[extra]"
+        "!pip install pyglet"
       ],
       "execution_count": 1,
       "outputs": [
@@ -231,7 +232,7 @@
         "\n",
         "\"A pole is attached by an un-actuated joint to a cart, which moves along a frictionless track. The system is controlled by applying a force of +1 or -1 to the cart. The pendulum starts upright, and the goal is to prevent it from falling over. A reward of +1 is provided for every timestep that the pole remains upright. \"\n",
         "\n",
-        "Cartpole environment: [https://gym.openai.com/envs/CartPole-v1/](https://gym.openai.com/envs/CartPole-v1/)\n",
+        "Cartpole environment: [https://www.gymlibrary.dev/environments/classic_control/cart_pole/](https://www.gymlibrary.dev/environments/classic_control/cart_pole/)\n",
         "\n",
         "![Cartpole](https://cdn-images-1.medium.com/max/1143/1*h4WTQNVIsvMXJTCpXm_TAw.gif)\n",
         "\n",
@@ -240,7 +241,7 @@
         "\n",
         "The type of action to use (discrete/continuous) will be automatically deduced from the environment action space\n",
         "\n",
-        "Here we are using the [Proximal Policy Optimization](https://stable-baselines3.readthedocs.io/en/master/modules/ppo2.html) algorithm, which is an Actor-Critic method: it uses a value function to improve the policy gradient descent (by reducing the variance).\n",
+        "Here we are using the [Proximal Policy Optimization](https://stable-baselines3.readthedocs.io/en/master/modules/ppo.html) algorithm, which is an Actor-Critic method: it uses a value function to improve the policy gradient descent (by reducing the variance).\n",
         "\n",
         "It combines ideas from [A2C](https://stable-baselines3.readthedocs.io/en/master/modules/a2c.html) (having multiple workers and using an entropy bonus for exploration) and [TRPO](https://stable-baselines.readthedocs.io/en/master/modules/trpo.html) (it uses a trust region to improve stability and avoid catastrophic drops in performance).\n",
         "\n",
@@ -563,14 +564,14 @@
         }
       },
       "source": [
-        "record_video('CartPole-v1', model, video_length=500, prefix='ppo2-cartpole')"
+        "record_video('CartPole-v1', model, video_length=500, prefix='ppo-cartpole')"
       ],
       "execution_count": 17,
       "outputs": [
         {
           "output_type": "stream",
           "text": [
-            "Saving video to  /content/videos/ppo2-cartpole-step-0-to-step-500.mp4\n"
+            "Saving video to  /content/videos/ppo-cartpole-step-0-to-step-500.mp4\n"
           ],
           "name": "stdout"
         }
@@ -584,7 +585,7 @@
         "colab": {}
       },
       "source": [
-        "show_videos('videos', prefix='ppo2')"
+        "show_videos('videos', prefix='ppo')"
       ],
       "execution_count": 0,
       "outputs": []

--- a/1_getting_started.ipynb
+++ b/1_getting_started.ipynb
@@ -75,7 +75,7 @@
       },
       "source": [
         "!apt-get install ffmpeg freeglut3-dev xvfb  # For visualization\n",
-        "!pip install stable-baselines3[extra]"
+        "!pip install stable-baselines3[extra]",
         "!pip install pyglet"
       ],
       "execution_count": 1,

--- a/1_getting_started.ipynb
+++ b/1_getting_started.ipynb
@@ -76,7 +76,7 @@
       "source": [
         "!apt-get install ffmpeg freeglut3-dev xvfb  # For visualization\n",
         "!pip install stable-baselines3[extra]\n",
-        "!pip install pyglet"
+        "!pip install pyglet==1.4"
       ],
       "execution_count": 1,
       "outputs": [

--- a/1_getting_started.ipynb
+++ b/1_getting_started.ipynb
@@ -75,7 +75,7 @@
       },
       "source": [
         "!apt-get install ffmpeg freeglut3-dev xvfb  # For visualization\n",
-        "!pip install stable-baselines3[extra]",
+        "!pip install stable-baselines3[extra]\n",
         "!pip install pyglet"
       ],
       "execution_count": 1,


### PR DESCRIPTION
* Redirected ppo2 to ppo, since the former seems not to exist in that docs page.
* Redirect to the gymlibrary docs for CartPole, since the old link failed.
* Added pyglet==1.4 to the list of required packages to install, since one of the later cells needs this.

Tested by running all cells from the following Google colab link:
https://colab.research.google.com/github/dan-pandori/rl-tutorial-jnrr19/blob/linkfix/1_getting_started.ipynb

And verifying that the edited links went to reasonable locations.